### PR TITLE
Expo CI Scripts

### DIFF
--- a/.github/actions/setup-monorepo/action.yml
+++ b/.github/actions/setup-monorepo/action.yml
@@ -1,0 +1,46 @@
+name: Setup Monorepo
+description: Prepare and install everything for the monorepo
+
+inputs:
+  node-version:
+    description: Version of Node to use
+    default: 18.x
+
+  eas-version:
+    description: Version of EAS CLI to use
+    default: latest
+
+  expo-token:
+    description: Expo token to authenticate with
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: 🏗 Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: yarn
+        cache-dependency-path: './yarn.lock'
+
+    - name: 🏗 Setup Expo
+      uses: expo/expo-github-action@v8
+      with:
+        eas-version: ${{ inputs.eas-version }}
+        token: ${{ inputs.expo-token }}
+
+    - name: 📦 Instal Deps
+      run: yarn install
+      shell: bash
+
+    - name: ♻️ Restore Cache
+      uses: actions/cache@v3
+      with:
+        key: turbo-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          turbo-${{ runner.os }}
+        path: |
+          node_modules/.cache/turbo
+          apps/*/.turbo
+          packages/*/.turbo

--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -1,0 +1,82 @@
+name: EAS Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Platform to build for (all/android/ios)
+        type: choice
+        required: true
+        default: all
+        options:
+          - all
+          - android
+          - ios
+      profile:
+        description: EAS Profile
+        type: choice
+        required: true
+        default: dev-client-sim-build
+        options:
+          - dev-client-sim-build
+          - bundled-sim-build
+          - development
+          - staging
+          - production
+      versionBumpType:
+        description: 'Version Bump Type (only set for prod builds)'
+        required: true
+        default: 'none'
+        type: choice
+        options:
+          - none
+          - patch
+          - minor
+          - major
+
+env:
+  WORKING_DIRECTORY: apps/mobile
+  DOTENV_KEY: ${{ secrets.DOTENV_KEY }}
+
+jobs:
+  mobile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup Repo
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup Monorepo
+        uses: ./.github/actions/setup-monorepo
+        with:
+          expo-token: ${{ secrets.EXPO_CI_TOKEN }}
+
+      - name: ⬆️ Bump App Version - Patch
+        if: ${{ github.event.inputs.versionBumpType == 'patch' }}
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: ./scripts/bump_version.sh -p
+
+      - name: ⬆️ Bump App Version - Minor
+        if: ${{ github.event.inputs.versionBumpType == 'minor' }}
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: ./scripts/bump_version.sh -m
+
+      - name: ⬆️ Bump App Version - Major
+        if: ${{ github.event.inputs.versionBumpType == 'major' }}
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: ./scripts/bump_version.sh -M
+
+      - name: 👷 Commit Changes
+        if: ${{ github.event.inputs.versionBumpType != 'none' }}
+        uses: EndBug/add-and-commit@v9
+        with:
+          author_name: Dan Yalg
+          author_email: dan@thecodingforge.com.au
+          message: 'Automated Version Bump'
+          add: 'apps/mobile/app.json'
+
+      - name: 👷 Build Mobile Packages
+        run: yarn run build:mobile
+
+      - name: 🚀 EAS Build Mobile
+        working-directory: ${{ env.WORKING_DIRECTORY }}
+        run: eas build --non-interactive --no-wait --platform ${{ github.event.inputs.platform }} --profile ${{ github.event.inputs.profile }}

--- a/.github/workflows/eas-cleanup.yml
+++ b/.github/workflows/eas-cleanup.yml
@@ -1,0 +1,61 @@
+name: EAS Cleanup
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  changes:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    outputs:
+      mobile: ${{ steps.filter.outputs.mobile }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            mobile:
+              - 'apps/mobile/**'
+
+      - run: echo ${{ steps.filter.outputs.mobile }}
+
+  cleanup:
+    needs: changes
+    if: ${{ needs.changes.outputs.mobile == 'true' }}
+    timeout-minutes: 10
+    name: Cleanup Preview Channel and Branch
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/mobile
+    steps:
+      - name: 🏗 Setup Repo
+        uses: actions/checkout@v3
+
+      # if we are on the develpoment, staging or main branches, then exit early
+      - name: Check Branch
+        if: ${{ github.head_ref == 'development' || github.head_ref == 'staging' || github.head_ref == 'main' }}
+        run: exit 0
+
+      - name: 🏗 Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: yarn
+          cache-dependency-path: './yarn.lock'
+
+      - name: 🏗 Setup Expo
+        uses: expo/expo-github-action@v8
+        with:
+          expo-version: latest
+          eas-version: latest
+          token: ${{ secrets.EXPO_CI_TOKEN }}
+
+      - name: 🗑️ Delete Channel
+        run: eas channel:delete ${{ github.head_ref }} --non-interactive
+
+      - name: 🗑️ Delete Branch
+        run: eas branch:delete ${{ github.head_ref }} --non-interactive

--- a/.github/workflows/eas-update.yml
+++ b/.github/workflows/eas-update.yml
@@ -1,0 +1,72 @@
+name: EAS Update
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+concurrency:
+  group: ${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    outputs:
+      mobile: ${{ steps.filter.outputs.mobile }}
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            mobile:
+              - 'apps/mobile/**'
+
+      - run: echo ${{ steps.filter.outputs.mobile }}
+
+  update-mobile:
+    needs: changes
+    if: ${{ needs.changes.outputs.mobile == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🏗 Setup Repo
+        uses: actions/checkout@v3
+
+      - name: 🏗 Setup Monorepo
+        uses: ./.github/actions/setup-monorepo
+        with:
+          expo-token: ${{ secrets.EXPO_CI_TOKEN }}
+
+      - name: 👷 Build Mobile Packages
+        run: yarn run build:mobile
+
+      - name: 🕵️ Pull Env Vars
+        working-directory: apps/mobile
+        run: npx dotenv-vault pull development -m ${{ secrets.DOTENV_ME }}
+        env:
+          DOTENV_KEY: ${{ secrets.DOTENV_KEY }}
+          # https://github.com/expo/expo-github-action/issues/221
+
+      - name: 😷 Expo Doctor
+        working-directory: apps/mobile
+        run: npx expo-doctor
+
+      - name: 🚀 EAS Update Mobile
+        continue-on-error: true
+        uses: expo/expo-github-action/preview@v8
+        with:
+          working-directory: apps/mobile
+          command: eas update --auto --branch ${{ github.head_ref }} --non-interactive
+
+  mobile-update-ignored:
+    timeout-minutes: 5
+    needs: changes
+    if: ${{ needs.changes.outputs.mobile == 'false' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            :no_entry: This PR does not contain changes to the mobile app. No Expo Preview Deployment will be created.


### PR DESCRIPTION
# Approach
- Combined the IMPT approach and also used this [Monorepo](https://github.com/byCedric/expo-monorepo-example) as inspiration in terms of using turbo build scripts to filter 

## Todos
- Still need to add `GH_PAT` for private repos
- Need to add dotenv vault pull into the build script, was just testing the update stuff with it first
- Hopefully the expo update JSON issue resolves and we can use dotenv-vault pull in the script